### PR TITLE
C2PA-37: Re-enable xmp_write feature using latest sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 [[package]]
 name = "c2pa"
 version = "0.16.1"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#7b1fec8f318a97ec85bf1a234be8627fd5d01276"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=feature/C2PA-37/xmp#ed6841a9fcaddb6407cecac160aeeb992e2a42b5"
 dependencies = [
  "atree",
  "base64",
@@ -320,6 +320,7 @@ dependencies = [
  "web-sys",
  "x509-certificate",
  "x509-parser",
+ "xmp_toolkit",
 ]
 
 [[package]]
@@ -906,6 +907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +977,12 @@ checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -1053,6 +1066,16 @@ dependencies = [
  "bytes",
  "crc32fast",
  "miniz_oxide 0.5.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1281,6 +1304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1396,27 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d829733185c1ca374f17e52b762f24f535ec625d2cc1f070e34c8a9068f341b"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be1598bf1c313dcdd12092e3f1920f463462525a21b7b4e11b4168353d0123e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1599,6 +1652,16 @@ checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2183,6 +2246,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_edit"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "toml_datetime",
+]
+
+[[package]]
 name = "twoway"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,6 +2574,18 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
+ "thiserror",
+]
+
+[[package]]
+name = "xmp_toolkit"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a598cac2b6809374a4a90c5038b80969aab30fcdf2f80574496c6855074f47"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "num_enum",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 [[package]]
 name = "c2pa"
 version = "0.16.1"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=feature/C2PA-37/xmp#ed6841a9fcaddb6407cecac160aeeb992e2a42b5"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#528acc78a0460251c9402235242c9a23c89d08d7"
 dependencies = [
  "atree",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = {git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["bmff", "otf", "fetch_remote_manifests", "file_io"]}
+c2pa = {git = "https://github.com/Monotype/c2pa-rs", branch = "feature/C2PA-37/xmp", features=["bmff", "otf", "fetch_remote_manifests", "file_io", "xmp_write"]}
 env_logger = "0.9"
 log = "0.4" 
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = {git = "https://github.com/Monotype/c2pa-rs", branch = "feature/C2PA-37/xmp", features=["bmff", "otf", "fetch_remote_manifests", "file_io", "xmp_write"]}
+c2pa = {git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["bmff", "otf", "fetch_remote_manifests", "file_io", "xmp_write"]}
 env_logger = "0.9"
 log = "0.4" 
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._

This updates to the latest SDK support for running the SDK with `xmp_write` support for image formats and fonts at the same point. This PR should not merge until https://github.com/Monotype/c2pa-rs/pull/1 has merged, and then the branch should be updated.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
