### PR TITLE
C2PA-147: Update to pick up the changes from the SDK for general box hashes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "c2pa"
 version = "0.24.0"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#a901145ddab82b886e33ba64ed4f31e49b1d9109"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=feature/C2PA-147/generalBoxHashes#5eccbc75456d27dde9c9233e5a33dfbbf1a8ac11"
 dependencies = [
  "asn1-rs",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "c2pa"
 version = "0.24.0"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=feature/C2PA-147/generalBoxHashes#5eccbc75456d27dde9c9233e5a33dfbbf1a8ac11"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#614bd1110be5fb3bb869ee43c235149057541908"
 dependencies = [
  "asn1-rs",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["otf", "fetch_remote_manifests", "file_io",  "xmp_write"] }
+#c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["otf", "fetch_remote_manifests", "file_io",  "xmp_write"] }
+c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "feature/C2PA-147/generalBoxHashes", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
+#c2pa = { path="../c2pa-rs/sdk", features=["otf", "fetch_remote_manifests", "file_io",  "add_thumbnails", "xmp_write"] }
 chrono = { version = "0.4.24" }
 clap = { version = "3.2", features = ["derive"] }
 env_logger = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-#c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["otf", "fetch_remote_manifests", "file_io",  "xmp_write"] }
-c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "feature/C2PA-147/generalBoxHashes", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
-#c2pa = { path="../c2pa-rs/sdk", features=["otf", "fetch_remote_manifests", "file_io",  "add_thumbnails", "xmp_write"] }
+c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
 chrono = { version = "0.4.24" }
 clap = { version = "3.2", features = ["derive"] }
 env_logger = "0.9"


### PR DESCRIPTION
<!--  Title should use the format: "JIRA-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/JIRA-123/featureName"  -->
<!--        Branch names for Bugs: "fix/JIRA-123/bugFixName"       -->
# JIRA Issue

- https://monotype.atlassian.net/browse/C2PA-147

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

References the latest additions for general box hash support for fonts.

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

Should test out signing a font with and without a remote manifest.

```
cargo run -- ..\HELVETICANOWMTTEXT.OTF --manifest manifest.json --output ..\HELVETICANOWMTTEXT.signed.OTF --force
```

And see help usage for `--remote`.

> Actively maintained by the @Monotype/driverpdldev team.
