### PR TITLE
C2PA-250: Update to the branch with the fix from the SDK.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "c2pa"
 version = "0.24.0"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=fix/C2PA-250/rewindStreamAgain#04626bc42d5107e9b65d4c9cb55e1c9d49c9ac9e"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#ce13f6e90d69a9b0e6f2550b2888dd534ac75cdf"
 dependencies = [
  "asn1-rs",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "c2pa"
 version = "0.24.0"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#614bd1110be5fb3bb869ee43c235149057541908"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=fix/C2PA-250/rewindStreamAgain#04626bc42d5107e9b65d4c9cb55e1c9d49c9ac9e"
 dependencies = [
  "asn1-rs",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
+c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "fix/C2PA-250/rewindStreamAgain", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
+#c2pa = { path="../c2pa-rs/sdk", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
 chrono = { version = "0.4.24" }
 clap = { version = "3.2", features = ["derive"] }
 env_logger = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ repository = "https://github.com/contentauth/c2patool"
 [dependencies]
 anyhow = "1.0"
 c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
-#c2pa = { path="../c2pa-rs/sdk", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
 chrono = { version = "0.4.24" }
 clap = { version = "3.2", features = ["derive"] }
 env_logger = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "fix/C2PA-250/rewindStreamAgain", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
+c2pa = { git = "https://github.com/Monotype/c2pa-rs", branch = "monotype/fontSupport", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
 #c2pa = { path="../c2pa-rs/sdk", features=["otf", "fetch_remote_manifests", "file_io", "add_thumbnails", "xmp_write"] }
 chrono = { version = "0.4.24" }
 clap = { version = "3.2", features = ["derive"] }


### PR DESCRIPTION
<!--  Title should use the format: "JIRA-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/JIRA-123/featureName"  -->
<!--        Branch names for Bugs: "fix/JIRA-123/bugFixName"       -->
# JIRA Issue

- https://monotype.atlassian.net/browse/C2PA-250

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

References the latest fixes in the SDK for regression issue of rewinding the input stream. Depends on: https://github.com/Monotype/c2pa-rs/pull/14

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

Should test out signing a font with and without a remote manifest.

```
cargo run -- ..\HELVETICANOWMTTEXT.OTF --manifest manifest.json --output ..\HELVETICANOWMTTEXT.signed.OTF --force
```

And see help usage for `--remote`.

> Actively maintained by the @Monotype/driverpdldev team.

