### PR TITLE
C2PA-557: Update c2patool to utilize latest c2pa-rs (with sidecar manifests for fonts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 [[package]]
 name = "c2pa"
 version = "0.35.0"
-source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#09bd27b8e4042486c43db7980237f4314f4aa688"
+source = "git+https://github.com/Monotype/c2pa-rs?branch=monotype/fontSupport#419cbaf2df20d8822e7cccb5fbfa8b2f32ccd649"
 dependencies = [
  "asn1-rs",
  "async-generic",
@@ -4264,7 +4264,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -52,3 +52,6 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []
+
+[sources.allow-org]
+github = ["Monotype"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -618,7 +618,8 @@ fn main() -> Result<()> {
                 if args.detailed {
                     println!(
                         "{}",
-                        ManifestStoreReport::from_file(&output, !is_sidecar).map_err(special_errs)?
+                        ManifestStoreReport::from_file(&output, !is_sidecar)
+                            .map_err(special_errs)?
                     );
                 } else {
                     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ mod info;
 mod callback_signer;
 mod signer;
 
+// file extension for external manifests
+const MANIFEST_STORE_EXT: &str = "c2pa";
+
 /// Tool for displaying and creating C2PA manifests.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None, arg_required_else_help(true))]
@@ -479,6 +482,11 @@ fn main() -> Result<()> {
     //     return Ok(());
     // }
 
+    // Determine if the asset is a sidecar.
+    let is_sidecar = path
+        .extension()
+        .map_or(false, |ext| ext == MANIFEST_STORE_EXT);
+
     // if we have a manifest config, process it
     if args.manifest.is_some() || args.config.is_some() {
         // read the json from file or config, and get base path if from file
@@ -610,12 +618,12 @@ fn main() -> Result<()> {
                 if args.detailed {
                     println!(
                         "{}",
-                        ManifestStoreReport::from_file(&output).map_err(special_errs)?
+                        ManifestStoreReport::from_file(&output, !is_sidecar).map_err(special_errs)?
                     );
                 } else {
                     println!(
                         "{}",
-                        ManifestStore::from_file(&output).map_err(special_errs)?
+                        ManifestStore::from_file(&output, !is_sidecar).map_err(special_errs)?
                     )
                 }
             }
@@ -643,13 +651,13 @@ fn main() -> Result<()> {
             File::create(output.join("ingredient.json"))?.write_all(&report.into_bytes())?;
             println!("Ingredient report written to the directory {:?}", &output);
         } else {
-            let report = ManifestStore::from_file_with_resources(&args.path, &output)
+            let report = ManifestStore::from_file_with_resources(&args.path, &output, !is_sidecar)
                 .map_err(special_errs)?
                 .to_string();
             if args.detailed {
                 // for a detailed report first call the above to generate the thumbnails
                 // then call this to add the detailed report
-                let detailed = ManifestStoreReport::from_file(&args.path)
+                let detailed = ManifestStoreReport::from_file(&args.path, !is_sidecar)
                     .map_err(special_errs)?
                     .to_string();
                 File::create(output.join("detailed.json"))?.write_all(&detailed.into_bytes())?;
@@ -665,7 +673,7 @@ fn main() -> Result<()> {
     } else if args.detailed {
         println!(
             "{}",
-            ManifestStoreReport::from_file(&args.path).map_err(special_errs)?
+            ManifestStoreReport::from_file(&args.path, !is_sidecar).map_err(special_errs)?
         )
     } else if let Some(Commands::Fragment {
         fragments_glob: Some(fg),
@@ -680,7 +688,7 @@ fn main() -> Result<()> {
     } else {
         println!(
             "{}",
-            ManifestStore::from_file(&args.path).map_err(special_errs)?
+            ManifestStore::from_file(&args.path, !is_sidecar).map_err(special_errs)?
         )
     }
 
@@ -724,7 +732,7 @@ pub mod tests {
             .embed(SOURCE_PATH, OUTPUT_PATH, signer.as_ref())
             .expect("embed");
 
-        let ms = ManifestStore::from_file(OUTPUT_PATH)
+        let ms = ManifestStore::from_file(OUTPUT_PATH, true)
             .expect("from_file")
             .to_string();
         //let ms = report_from_path(&OUTPUT_PATH, false).expect("report_from_path");


### PR DESCRIPTION
## Changes in this pull request

- Updates `c2pa-rs` SDK's `monotype/fontSupport` branch reference to the most recent update (supporting sidecar manifests for fonts)
- Fixed up `main.rs` to support the change in the API

## Verification Instructions

- Build `c2patool` from this branch
  - `cargo build`
- Use `c2patool` to sign a font
  -  `target/debug/c2patool.exe <font.ttf> -m sample/test.json -f -d -s -o <font_out.ttf>`
- Inspect the font with c2patool to verify that it was correctly signed and that all signature/hashes are valid
  - `target/debug/c2patool.exe <font_out.c2pa> -d`

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
